### PR TITLE
Assume an observation at t=0

### DIFF
--- a/src/microstructure.jl
+++ b/src/microstructure.jl
@@ -120,11 +120,11 @@ function MCMC(Π::Union{Prior,Dict}, tt, y, α0::Float64, σα, iterations; subi
 
 
     Z = zeros(N)
-    ii = Vector(N)
+    ii = Vector(N) # vector of start indices of increments
     td = zeros(N+1)
     for k in 1:N
         if k == N
-            ii[k] = 1+(k-1)*m:n
+            ii[k] = 1+(k-1)*m:n # sic!
         else
             ii[k] = 1+(k-1)*m:(k)*m
         end

--- a/src/microstructure.jl
+++ b/src/microstructure.jl
@@ -210,10 +210,14 @@ function MCMC(Π::Union{Prior,Dict}, tt, y, α0::Float64, σα, iterations; subi
         if eta == 0.0 && fixeta
             # do nothing
         else 
-            C[1] = C0
-            μ[1] = μ0
-            μi = μ0
-            Ci = C0
+            wi = 0.0 
+            Ki = C0/(C0 + η)
+            μi =  μ0 + Ki*(y[1] - μ0)
+
+            Ci = Ki*η
+            C[1] = Ci
+            μ[1] = μi
+
             for k in 1:N
                 iik = ii[k]
                 for i in iik # from 1 to n


### PR DESCRIPTION
Currently the first entry of the vector of observations is ignored as in the paper there is no observation at t=0. In general it seems to be more useful to have an observation also at time t=0 and change 

https://github.com/mschauer/MicrostructureNoise.jl/pull/2/commits/4bd44e0a2e1a283021db923c9a20016e1c742a2b

accordingly.